### PR TITLE
Add localizations to each version using .properties & Fluent

### DIFF
--- a/src-1.0/chrome.manifest
+++ b/src-1.0/chrome.manifest
@@ -1,3 +1,4 @@
 content   make-it-red             chrome/content/
 skin      make-it-red   default   chrome/skin/
+locale    make-it-red   en-US     chrome/locale/en-US/
 overlay	chrome://zotero/content/zoteroPane.xul chrome://make-it-red/content/overlay.xul

--- a/src-1.0/chrome/content/lib.js
+++ b/src-1.0/chrome/content/lib.js
@@ -6,6 +6,17 @@ if (!Zotero.MakeItRed) {
 		
 		async foo() {
 			this.log("Foo");
+		},
+
+		toggleGreen(enabled) {
+			let docElem = Zotero.getMainWindow().document.documentElement;
+			// Element#toggleAttribute() is not supported in Zotero 6
+			if (enabled) {
+				docElem.setAttribute('data-green-instead', 'true');
+			}
+			else {
+				docElem.removeAttribute('data-green-instead');
+			}
 		}
 	};
 }

--- a/src-1.0/chrome/content/overlay.js
+++ b/src-1.0/chrome/content/overlay.js
@@ -6,6 +6,10 @@ async function init() {
 	log("Initializing");
 	await Zotero.initializationPromise;
 	Zotero.MakeItRed.foo();
+	
+	let stringBundle = Services.strings.createBundle('chrome://make-it-red/locale/make-it-red.properties');
+	Zotero.getMainWindow().document.getElementById('make-it-green-instead')
+		.setAttribute('label', stringBundle.GetStringFromName('makeItGreenInstead.label'));
 }
 
 window.addEventListener('load', function (event) {

--- a/src-1.0/chrome/content/overlay.xul
+++ b/src-1.0/chrome/content/overlay.xul
@@ -5,4 +5,10 @@
 		xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
 	<script src="overlay.js"/>
 	<script src="lib.js"/>
+	
+	<menupopup id="menu_viewPopup">
+		<menuitem id="make-it-green-instead"
+				  type="checkbox"
+				  oncommand="Zotero.MakeItRed.toggleGreen(this.getAttribute('checked') === 'true')"/>
+	</menupopup>
 </overlay>

--- a/src-1.0/chrome/locale/en-US/make-it-red.properties
+++ b/src-1.0/chrome/locale/en-US/make-it-red.properties
@@ -1,0 +1,1 @@
+makeItGreenInstead.label = Make It Green Instead

--- a/src-1.0/chrome/skin/overlay.css
+++ b/src-1.0/chrome/skin/overlay.css
@@ -1,3 +1,7 @@
 .row {
 	color: #D70040;
 }
+
+window[data-green-instead] .row {
+	color: forestgreen;
+}

--- a/src-1.1/chrome.manifest
+++ b/src-1.1/chrome.manifest
@@ -1,3 +1,4 @@
 content   make-it-red             chrome/content/
 skin      make-it-red   default   chrome/skin/
+locale    make-it-red   en-US     chrome/locale/en-US/
 overlay	chrome://zotero/content/zoteroPane.xul chrome://make-it-red/content/overlay.xul

--- a/src-1.1/chrome/content/lib.js
+++ b/src-1.1/chrome/content/lib.js
@@ -6,6 +6,17 @@ if (!Zotero.MakeItRed) {
 		
 		async foo() {
 			this.log("Foo");
+		},
+		
+		toggleGreen(enabled) {
+			let docElem = Zotero.getMainWindow().document.documentElement;
+			// Element#toggleAttribute() is not supported in Zotero 6
+			if (enabled) {
+				docElem.setAttribute('data-green-instead', 'true');
+			}
+			else {
+				docElem.removeAttribute('data-green-instead');
+			}
 		}
 	};
 }

--- a/src-1.1/chrome/content/overlay.js
+++ b/src-1.1/chrome/content/overlay.js
@@ -6,6 +6,12 @@ async function init() {
 	log("Initializing");
 	await Zotero.initializationPromise;
 	Zotero.MakeItRed.foo();
+
+	// Use strings from make-it-red.properties -
+	// Fluent is available in Zotero 6 but unreliable and difficult to configure
+	let stringBundle = Services.strings.createBundle('chrome://make-it-red/locale/make-it-red.properties');
+	Zotero.getMainWindow().document.getElementById('make-it-green-instead')
+		.setAttribute('label', stringBundle.GetStringFromName('makeItGreenInstead.label'));
 }
 
 window.addEventListener('load', function (event) {

--- a/src-1.1/chrome/content/overlay.xul
+++ b/src-1.1/chrome/content/overlay.xul
@@ -5,4 +5,10 @@
 		xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
 	<script src="overlay.js"/>
 	<script src="lib.js"/>
+	
+	<menupopup id="menu_viewPopup">
+		<menuitem id="make-it-green-instead"
+				  type="checkbox"
+				  oncommand="Zotero.MakeItRed.toggleGreen(this.getAttribute('checked') === 'true')"/>
+	</menupopup>
 </overlay>

--- a/src-1.1/chrome/locale/en-US/make-it-red.properties
+++ b/src-1.1/chrome/locale/en-US/make-it-red.properties
@@ -1,0 +1,1 @@
+makeItGreenInstead.label = Make It Green Instead

--- a/src-1.1/chrome/skin/overlay.css
+++ b/src-1.1/chrome/skin/overlay.css
@@ -1,3 +1,7 @@
 .row {
 	color: #D70040;
 }
+
+window[data-green-instead] .row {
+	color: forestgreen;
+}

--- a/src-1.1/lib.js
+++ b/src-1.1/lib.js
@@ -6,6 +6,11 @@ if (!Zotero.MakeItRed) {
 		
 		async foo() {
 			this.log("Foo");
+		},
+
+		toggleGreen(enabled) {
+			Zotero.getMainWindow().document.documentElement
+				.toggleAttribute('data-green-instead', enabled);
 		}
 	};
 }

--- a/src-1.1/locale/en-US/make-it-red.ftl
+++ b/src-1.1/locale/en-US/make-it-red.ftl
@@ -1,0 +1,2 @@
+make-it-green-instead =
+    .label = Make It Green Instead

--- a/src-1.1/style.css
+++ b/src-1.1/style.css
@@ -1,3 +1,7 @@
 .row {
 	color: red;
 }
+
+window[data-green-instead] .row {
+	color: green;
+}

--- a/src-1.2/chrome.manifest
+++ b/src-1.2/chrome.manifest
@@ -1,0 +1,1 @@
+locale    make-it-red   en-US     chrome/locale/en-US/

--- a/src-1.2/chrome/locale/en-US/make-it-red.properties
+++ b/src-1.2/chrome/locale/en-US/make-it-red.properties
@@ -1,0 +1,1 @@
+makeItGreenInstead.label = Make It Green Instead

--- a/src-1.2/lib.js
+++ b/src-1.2/lib.js
@@ -6,6 +6,17 @@ if (!Zotero.MakeItRed) {
 		
 		async foo() {
 			this.log("Foo");
+		},
+
+		toggleGreen(enabled) {
+			let docElem = Zotero.getMainWindow().document.documentElement;
+			// Element#toggleAttribute() is not supported in Zotero 6
+			if (enabled) {
+				docElem.setAttribute('data-green-instead', 'true');
+			}
+			else {
+				docElem.removeAttribute('data-green-instead');
+			}
 		}
 	};
 }

--- a/src-1.2/locale/en-US/make-it-red.ftl
+++ b/src-1.2/locale/en-US/make-it-red.ftl
@@ -1,0 +1,2 @@
+make-it-green-instead =
+    .label = Make It Green Instead

--- a/src-1.2/style.css
+++ b/src-1.2/style.css
@@ -1,3 +1,7 @@
 .row {
 	color: red;
 }
+
+window[data-green-instead] .row {
+	color: green;
+}

--- a/src-2.0/bootstrap.js
+++ b/src-2.0/bootstrap.js
@@ -1,4 +1,7 @@
 var stylesheetID = 'make-it-red-stylesheet';
+var ftlID = 'make-it-red-ftl';
+var menuitemID = 'make-it-green-instead';
+var addedElementIDs = [stylesheetID, ftlID, menuitemID];
 
 function log(msg) {
 	Zotero.debug("Make It Red: " + msg);
@@ -15,12 +18,26 @@ async function startup({ id, version, rootURI }) {
 	var zp = Zotero.getActiveZoteroPane();
 	if (zp) {
 		let doc = zp.document;
-		let link = doc.createElement('link');
-		link.id = stylesheetID;
-		link.type = 'text/css';
-		link.rel = 'stylesheet';
-		link.href = rootURI + 'style.css';
-		doc.documentElement.appendChild(link);
+		let link1 = doc.createElement('link');
+		link1.id = stylesheetID;
+		link1.type = 'text/css';
+		link1.rel = 'stylesheet';
+		link1.href = rootURI + 'style.css';
+		doc.documentElement.appendChild(link1);
+
+		let link2 = doc.createElement('link');
+		link2.id = ftlID;
+		link2.rel = 'localization';
+		link2.href = 'make-it-red.ftl';
+		doc.documentElement.appendChild(link2);
+
+		let menuitem = doc.createXULElement('menuitem');
+		menuitem.id = menuitemID;
+		menuitem.setAttribute('type', 'checkbox');
+		menuitem.setAttribute('data-l10n-id', 'make-it-green-instead');
+		// MozMenuItem#checked is available in Zotero 7
+		menuitem.addEventListener('command', () => Zotero.MakeItRed.toggleGreen(menuitem.checked));
+		doc.getElementById('menu_viewPopup').appendChild(menuitem);
 	}
 	
 	Services.scriptloader.loadSubScript(rootURI + 'lib.js');
@@ -33,8 +50,9 @@ function shutdown() {
 	// Remove stylesheet
 	var zp = Zotero.getActiveZoteroPane();
 	if (zp) {
-		let stylesheet = zp.document.getElementById(stylesheetID);
-		stylesheet.parentNode.removeChild(stylesheet);
+		for (let id of addedElementIDs) {
+			zp.document.getElementById(id)?.remove();
+		}
 	}
 }
 

--- a/src-2.0/lib.js
+++ b/src-2.0/lib.js
@@ -6,6 +6,11 @@ if (!Zotero.MakeItRed) {
 		
 		async foo() {
 			this.log("Make It Red: Foo");
+		},
+		
+		toggleGreen(enabled) {
+			Zotero.getMainWindow().document.documentElement
+				.toggleAttribute('data-green-instead', enabled);
 		}
 	};
 }

--- a/src-2.0/locale/en-US/make-it-red.ftl
+++ b/src-2.0/locale/en-US/make-it-red.ftl
@@ -1,0 +1,2 @@
+make-it-green-instead =
+    .label = Make It Green Instead

--- a/src-2.0/style.css
+++ b/src-2.0/style.css
@@ -1,3 +1,7 @@
 .row {
 	color: red;
 }
+
+window[data-green-instead] .row {
+	color: green;
+}


### PR DESCRIPTION
To power a useful new color-changing feature.

I wanted to use only Fluent in all versions besides 1.0, but, while it is technically supported in Fx63, it's messy:

- We need to add a [polyfill](https://searchfox.org/mozilla-esr60/source/intl/l10n/l10n.js) that runs on load so we have to rely on a hack to get it to run
	- We'd need to load the polyfill and apply that hack to every window we want to use Fluent localizations in
- It doesn't pick up on new `<link rel="localization">` tags added to the document after load time, only ones that were there from the beginning, so we need another hack to get around that for bootstrapped extensions
- The process to load a new file source is different and incompatible

All in all, not really worth it.