### PR TITLE
Ensure main window listener is properly added/removed in Zotero 6

### DIFF
--- a/src-1.2/bootstrap.js
+++ b/src-1.2/bootstrap.js
@@ -61,7 +61,7 @@ function listenForMainWindowEvents() {
 				.getInterface(Ci.nsIDOMWindowInternal || Ci.nsIDOMWindow);
 			async function onload() {
 				domWindow.removeEventListener("load", onload, false);
-				if (domWindow.location.href !== "chrome://zotero/content/zoteroPane.xhtml") {
+				if (domWindow.location.href !== "chrome://zotero/content/standalone/standalone.xul") {
 					return;
 				}
 				onMainWindowLoad({ window: domWindow });
@@ -71,7 +71,7 @@ function listenForMainWindowEvents() {
 		onCloseWindow: async function (aWindow) {
 			let domWindow = aWindow.QueryInterface(Ci.nsIInterfaceRequestor)
 				.getInterface(Ci.nsIDOMWindowInternal || Ci.nsIDOMWindow);
-			if (domWindow.location.href !== "chrome://zotero/content/zoteroPane.xhtml") {
+			if (domWindow.location.href !== "chrome://zotero/content/standalone/standalone.xul") {
 				return;
 			}
 			onMainWindowUnload({ window: domWindow });

--- a/src-1.2/bootstrap.js
+++ b/src-1.2/bootstrap.js
@@ -3,6 +3,8 @@ if (typeof Zotero == 'undefined') {
 }
 var MakeItRed;
 
+let mainWindowListener;
+
 function log(msg) {
 	Zotero.debug("Make It Red: " + msg);
 }
@@ -55,7 +57,7 @@ async function waitForZotero() {
 
 // Adds main window open/close listeners in Zotero 6
 function listenForMainWindowEvents() {
-	const mainWindowListener = {
+	mainWindowListener = {
 		onOpenWindow: function (aWindow) {
 			let domWindow = aWindow.QueryInterface(Ci.nsIInterfaceRequestor)
 				.getInterface(Ci.nsIDOMWindowInternal || Ci.nsIDOMWindow);
@@ -80,6 +82,11 @@ function listenForMainWindowEvents() {
 	Services.wm.addListener(mainWindowListener);
 }
 
+function removeMainWindowListener() {
+	if (mainWindowListener) {
+		Services.wm.removeListener(mainWindowListener);
+	}
+}
 
 // Loads default preferences from prefs.js in Zotero 6
 function setDefaultPrefs(rootURI) {
@@ -146,6 +153,11 @@ function onMainWindowUnload({ window }) {
 
 function shutdown() {
 	log("Shutting down 1.2");
+
+	if (Zotero.platformMajorVersion < 102) {
+		removeMainWindowListener();
+	}
+
 	MakeItRed.removeFromAllWindows();
 	MakeItRed = undefined;
 }

--- a/src-1.2/bootstrap.js
+++ b/src-1.2/bootstrap.js
@@ -119,9 +119,9 @@ async function install() {
 }
 
 async function startup({ id, version, resourceURI, rootURI = resourceURI.spec }) {
-	log("Starting 1.2");
-	
 	await waitForZotero();
+	
+	log("Starting 1.2");
 	
 	// 'Services' may not be available in Zotero 6
 	if (typeof Services == 'undefined') {


### PR DESCRIPTION
After using the update in #4 to implement support for main window load/unload in my plugin, I discovered a few issues when testing in Zotero 6. This PR fixes issues related to the following:

- In Z6, the main window URI is `chrome://zotero/content/standalone/standalone.xul` rather than `chrome://zotero/content/zoteroPane.xhtml`.
- `mainWindowListener` was not being removed from the window mediator upon plugin shutdown. If a plugin was enabled, disabled, and then re-enabled, it would end up with multiple main window listeners.
- `startup` was calling `log` before `waitForZotero`, resulting in a `Zotero is undefined` error upon plugin startup.