### PR TITLE
Change plugin ID domain from zotero.org to example.com

### DIFF
--- a/make-zips
+++ b/make-zips
@@ -14,13 +14,13 @@ cd ../src-2.0
 zip -r ../build/make-it-red-2.0.xpi *
 cd ../build
 
-jq ".addons[\"make-it-red@zotero.org\"].updates[0].update_hash = \"sha256:`shasum -a 256 make-it-red-1.1.xpi | cut -d' ' -f1`\"" ../updates-1.0.json.tmpl > updates-1.0.json
+jq ".addons[\"make-it-red@example.com\"].updates[0].update_hash = \"sha256:`shasum -a 256 make-it-red-1.1.xpi | cut -d' ' -f1`\"" ../updates-1.0.json.tmpl > updates-1.0.json
 cp updates-1.0.json update.rdf
 
-jq ".addons[\"make-it-red@zotero.org\"].updates[0].update_hash = \"sha256:`shasum -a 256 make-it-red-1.2.xpi | cut -d' ' -f1`\"" ../updates-1.1.json.tmpl | \
-	jq ".addons[\"make-it-red@zotero.org\"].updates[1].update_hash = \"sha256:`shasum -a 256 make-it-red-2.0.xpi | cut -d' ' -f1`\"" > updates-1.1.json
+jq ".addons[\"make-it-red@example.com\"].updates[0].update_hash = \"sha256:`shasum -a 256 make-it-red-1.2.xpi | cut -d' ' -f1`\"" ../updates-1.1.json.tmpl | \
+	jq ".addons[\"make-it-red@example.com\"].updates[1].update_hash = \"sha256:`shasum -a 256 make-it-red-2.0.xpi | cut -d' ' -f1`\"" > updates-1.1.json
 
-jq ".addons[\"make-it-red@zotero.org\"].updates[0].update_hash = \"sha256:`shasum -a 256 make-it-red-1.2.xpi | cut -d' ' -f1`\"" ../updates-1.2.json.tmpl | \
-	jq ".addons[\"make-it-red@zotero.org\"].updates[1].update_hash = \"sha256:`shasum -a 256 make-it-red-2.0.xpi | cut -d' ' -f1`\"" > updates-1.2.json
+jq ".addons[\"make-it-red@example.com\"].updates[0].update_hash = \"sha256:`shasum -a 256 make-it-red-1.2.xpi | cut -d' ' -f1`\"" ../updates-1.2.json.tmpl | \
+	jq ".addons[\"make-it-red@example.com\"].updates[1].update_hash = \"sha256:`shasum -a 256 make-it-red-2.0.xpi | cut -d' ' -f1`\"" > updates-1.2.json
 
-jq ".addons[\"make-it-red@zotero.org\"].updates[0].update_hash = \"sha256:`shasum -a 256 make-it-red-2.0.xpi | cut -d' ' -f1`\"" ../updates-2.0.json.tmpl > updates-2.0.json
+jq ".addons[\"make-it-red@example.com\"].updates[0].update_hash = \"sha256:`shasum -a 256 make-it-red-2.0.xpi | cut -d' ' -f1`\"" ../updates-2.0.json.tmpl > updates-2.0.json

--- a/src-1.0/install.rdf
+++ b/src-1.0/install.rdf
@@ -3,7 +3,7 @@
         xmlns:em="http://www.mozilla.org/2004/em-rdf#">
 
     <Description about="urn:mozilla:install-manifest">
-        <em:id>make-it-red@zotero.org</em:id>
+        <em:id>make-it-red@example.com</em:id>
         <em:name>Make It Red</em:name>
         <em:version>1.0</em:version>
         <em:multiprocessCompatible>true</em:multiprocessCompatible>

--- a/src-1.1/install.rdf
+++ b/src-1.1/install.rdf
@@ -3,7 +3,7 @@
         xmlns:em="http://www.mozilla.org/2004/em-rdf#">
 
     <Description about="urn:mozilla:install-manifest">
-        <em:id>make-it-red@zotero.org</em:id>
+        <em:id>make-it-red@example.com</em:id>
         <em:name>Make It Red</em:name>
         <em:version>1.1</em:version>
         <em:multiprocessCompatible>true</em:multiprocessCompatible>

--- a/src-1.1/manifest.json
+++ b/src-1.1/manifest.json
@@ -6,7 +6,7 @@
 	"homepage_url": "https://github.com/zotero/make-it-red",
 	"applications": {
 		"zotero": {
-			"id": "make-it-red@zotero.org",
+			"id": "make-it-red@example.com",
 			"update_url": "https://zotero-download.s3.amazonaws.com/tmp/make-it-red/updates-1.1.json",
 			"strict_min_version": "6.999",
 			"strict_max_version": "7.0.*"

--- a/src-1.2/install.rdf
+++ b/src-1.2/install.rdf
@@ -3,7 +3,7 @@
         xmlns:em="http://www.mozilla.org/2004/em-rdf#">
 
     <Description about="urn:mozilla:install-manifest">
-        <em:id>make-it-red@zotero.org</em:id>
+        <em:id>make-it-red@example.com</em:id>
         <em:name>Make It Red</em:name>
         <em:version>1.2</em:version>
         <em:multiprocessCompatible>true</em:multiprocessCompatible>

--- a/src-1.2/manifest.json
+++ b/src-1.2/manifest.json
@@ -6,7 +6,7 @@
 	"homepage_url": "https://github.com/zotero/make-it-red",
 	"applications": {
 		"zotero": {
-			"id": "make-it-red@zotero.org",
+			"id": "make-it-red@example.com",
 			"update_url": "https://zotero-download.s3.amazonaws.com/tmp/make-it-red/updates-1.2.json",
 			"strict_min_version": "6.999",
 			"strict_max_version": "7.0.*"

--- a/src-2.0/bootstrap.js
+++ b/src-2.0/bootstrap.js
@@ -12,7 +12,7 @@ async function startup({ id, version, rootURI }) {
 	log("Starting 2.0");
 	
 	Zotero.PreferencePanes.register({
-		pluginID: 'make-it-red@zotero.org',
+		pluginID: 'make-it-red@example.com',
 		src: rootURI + 'preferences.xhtml',
 		scripts: [rootURI + 'preferences.js']
 	});

--- a/src-2.0/manifest.json
+++ b/src-2.0/manifest.json
@@ -6,7 +6,7 @@
 	"homepage_url": "https://github.com/zotero/make-it-red",
 	"applications": {
 		"zotero": {
-			"id": "make-it-red@zotero.org",
+			"id": "make-it-red@example.com",
 			"update_url": "https://zotero-download.s3.amazonaws.com/tmp/make-it-red/updates-2.0.json",
 			"strict_min_version": "6.999",
 			"strict_max_version": "7.0.*"

--- a/updates-1.0.json.tmpl
+++ b/updates-1.0.json.tmpl
@@ -1,6 +1,6 @@
 {
   "addons": {
-    "make-it-red@zotero.org": {
+    "make-it-red@example.com": {
       "updates": [
         {
           "version": "1.1",

--- a/updates-1.1.json.tmpl
+++ b/updates-1.1.json.tmpl
@@ -1,6 +1,6 @@
 {
   "addons": {
-    "make-it-red@zotero.org": {
+    "make-it-red@example.com": {
       "updates": [
         {
           "version": "1.2",

--- a/updates-1.2.json.tmpl
+++ b/updates-1.2.json.tmpl
@@ -1,6 +1,6 @@
 {
   "addons": {
-    "make-it-red@zotero.org": {
+    "make-it-red@example.com": {
       "updates": [
         {
           "version": "1.2",

--- a/updates-2.0.json.tmpl
+++ b/updates-2.0.json.tmpl
@@ -1,6 +1,6 @@
 {
   "addons": {
-    "make-it-red@zotero.org": {
+    "make-it-red@example.com": {
       "updates": [
         {
           "version": "2.0",


### PR DESCRIPTION
It isn't necessarily obvious that `@zotero.org` is a part of the ID that's meant to be modified. Using `@example.com` makes it clearer.

(I don't know how this will affect updates for people who already have the plugin installed, but it's not like this plugin actually does anything.)