### PR TITLE
Fix Issue #13: preferences.xhtml and preferences.js are missing in src-2.0

### DIFF
--- a/src-2.0/locale/en-US/make-it-red.ftl
+++ b/src-2.0/locale/en-US/make-it-red.ftl
@@ -1,2 +1,4 @@
 make-it-red-green-instead =
     .label = Make It Green Instead
+
+make-it-red-text-color = Text color:

--- a/src-2.0/make-it-red.js
+++ b/src-2.0/make-it-red.js
@@ -27,6 +27,8 @@ MakeItRed = {
 		link1.rel = 'stylesheet';
 		link1.href = this.rootURI + 'style.css';
 		doc.documentElement.appendChild(link1);
+		let color = Zotero.Prefs.get("extensions.make-it-red.color", "#ff0000");
+		doc.documentElement.style.setProperty('--make-it-red-style-color', color);
 		this.storeAddedElement(link1);
 		
 		// Use Fluent for localization

--- a/src-2.0/make-it-red.js
+++ b/src-2.0/make-it-red.js
@@ -89,5 +89,6 @@ MakeItRed = {
 		
 		// Retrieve a global pref
 		this.log(`Intensity is ${Zotero.Prefs.get('extensions.make-it-red.intensity', true)}`);
+		this.log(`Color is ${Zotero.Prefs.get('extensions.make-it-red.color', "#ff0000")}`);
 	},
 };

--- a/src-2.0/preferences.js
+++ b/src-2.0/preferences.js
@@ -1,4 +1,4 @@
-MakeItRed_Preferences = {
+window.MakeItRed_Preferences = {
 	init: function () {
 		Zotero.debug("Make It Red: Initialize preference pane");
   

--- a/src-2.0/preferences.js
+++ b/src-2.0/preferences.js
@@ -1,5 +1,14 @@
 MakeItRed_Preferences = {
 	init: function () {
 		Zotero.debug("Make It Red: Initialize preference pane");
+  
+		const picker = document.getElementById("make-it-red-color");
+		picker.addEventListener("input", (e) => {
+			for (let win of Zotero.getMainWindows()) {
+				if (!win.ZoteroPane) continue;
+				win.document.documentElement.style.setProperty('--make-it-red-style-color', e.target.value);
+			}
+		});
+
 	}
 };

--- a/src-2.0/preferences.js
+++ b/src-2.0/preferences.js
@@ -1,0 +1,5 @@
+MakeItRed_Preferences = {
+	init: function () {
+		Zotero.debug("Make It Red: Initialize preference pane");
+	}
+};

--- a/src-2.0/preferences.xhtml
+++ b/src-2.0/preferences.xhtml
@@ -1,0 +1,29 @@
+<vbox onload="MakeItRed_Preferences.init()">
+	<linkset>
+		<html:link rel="localization" href="make-it-red.ftl"/>
+	</linkset>
+	
+	<html:style>
+		#make-it-red-color {
+			width: 1em;
+			height: 1em;
+			padding: 0;
+			border: none;
+			appearance: none;
+		}
+	</html:style>
+
+	<groupbox>
+		<hbox align="center">
+			<html:label
+				for="make-it-red-color"
+				data-l10n-id="make-it-red-text-color"
+			></html:label>
+			<html:input
+				id="make-it-red-color"
+				preference="extensions.make-it-red.color" 
+				type="color"
+			></html:input>
+		</hbox>
+	</groupbox>
+</vbox>

--- a/src-2.0/prefs.js
+++ b/src-2.0/prefs.js
@@ -1,1 +1,2 @@
 pref("extensions.make-it-red.intensity", 100);
+pref("extensions.make-it-red.color",  "#ff0000");

--- a/src-2.0/style.css
+++ b/src-2.0/style.css
@@ -1,7 +1,7 @@
 .row {
-	color: red;
+	color: var(--make-it-red-style-color, red) !important;
 }
 
 window[data-green-instead] .row {
-	color: green;
+	color: var(--make-it-green-style-color, green) !important;
 }


### PR DESCRIPTION
This puts back in the missing files, so the Settings pane functions again; moreover, it changes the color (normally red) according to the Settings (and plays nice with the 'Make It Green Instead' menu item).
Here is what it looks like:
<img width="1918" height="1124" alt="image" src="https://github.com/user-attachments/assets/9e605f9f-ab4f-4c4c-8395-beb500896a4f" />
